### PR TITLE
Reset Password Implementado

### DIFF
--- a/clients/plataforma-principal/public/locales/en/LoginForm.json
+++ b/clients/plataforma-principal/public/locales/en/LoginForm.json
@@ -12,5 +12,16 @@
   "invalidCredentials": "Invalid username/email or password",
   "usernameOrEmailRequired": "Username or email is required",
   "serverError": "Server error - please try again later",
-  "invalidForm": "Please review the form fields"
+  "invalidForm": "Please review the form fields",
+
+  
+  "forgotPassword": "Forgot your password?",
+  "sendingReset": "Sending…",
+  "emailRequiredForReset": "Please enter a valid email to recover your password",
+  "resetEmailModal": {
+    "title": "Check your email",
+    "body": "If {{email}} exists, we have sent you instructions to reset your password. The link will expire in 15 minutes."
+  },
+  "ok": "OK"
+
 }

--- a/clients/plataforma-principal/public/locales/en/ResetPassword.json
+++ b/clients/plataforma-principal/public/locales/en/ResetPassword.json
@@ -1,0 +1,27 @@
+{
+  "title": "Reset password",
+  "fields": {
+    "newPassword": "New password",
+    "repeatPassword": "Repeat new password"
+  },
+  "actions": {
+    "save": "Save",
+    "cancel": "Cancel"
+  },
+  "subtitle": "Enter your new password and confirm it.",
+  "states": {
+    "saving": "Saving…"
+  },
+  "errors": {
+    "missingToken": "Reset token is missing in the URL.",
+    "shortPassword": "Password must be at least 8 characters.",
+    "passwordsDontMatch": "Passwords do not match.",
+    "generic": "Could not reset the password. Please try again.",
+    "network": "Network error. Check your connection."
+  },
+  "success": {
+    "title": "Password reset",
+    "body": "Your password has been changed successfully and your active sessions were closed for security.",
+    "goLogin": "Go to login"
+  }
+}

--- a/clients/plataforma-principal/public/locales/es/LoginForm.json
+++ b/clients/plataforma-principal/public/locales/es/LoginForm.json
@@ -12,5 +12,15 @@
   "invalidCredentials": "Usuario/email o contraseña incorrectos",
   "usernameOrEmailRequired": "El nombre de usuario o el email es obligatorio",
   "serverError": "Error del servidor - inténtalo de nuevo más tarde",
-  "invalidForm": "Revisa los campos del formulario"
+  "invalidForm": "Revisa los campos del formulario",
+
+  "forgotPassword": "¿Olvidaste tu contraseña?",
+  "sendingReset": "Enviando…",
+  "emailRequiredForReset": "Introduce un correo válido para recuperar tu contraseña",
+  "resetEmailModal": {
+    "title": "Revisa tu correo",
+    "body": "Si {{email}} existe, te hemos enviado instrucciones para restablecer tu contraseña. El enlace caduca en 15 minutos."
+  },
+  "ok": "Entendido"
+
 }

--- a/clients/plataforma-principal/public/locales/es/ResetPassword.json
+++ b/clients/plataforma-principal/public/locales/es/ResetPassword.json
@@ -1,0 +1,27 @@
+{
+  "title": "Restablecer contraseña",
+  "fields": {
+    "newPassword": "Nueva contraseña",
+    "repeatPassword": "Repite la nueva contraseña"
+  },
+  "actions": {
+    "save": "Guardar",
+    "cancel": "Cancelar"
+  },
+  "subtitle": "Introduce tu nueva contraseña y confírmala.",
+  "states": {
+    "saving": "Guardando…"
+  },
+  "errors": {
+    "missingToken": "Falta el token de restablecimiento en la URL.",
+    "shortPassword": "La contraseña debe tener al menos 8 caracteres.",
+    "passwordsDontMatch": "Las contraseñas no coinciden.",
+    "generic": "No se pudo restablecer la contraseña. Inténtalo de nuevo.",
+    "network": "Error de red. Comprueba tu conexión."
+  },
+  "success": {
+    "title": "Contraseña restablecida",
+    "body": "Tu contraseña se ha cambiado correctamente y hemos cerrado tus sesiones activas por seguridad.",
+    "goLogin": "Ir a iniciar sesión"
+  }
+}

--- a/clients/plataforma-principal/src/App.tsx
+++ b/clients/plataforma-principal/src/App.tsx
@@ -2,12 +2,14 @@ import { Routes, Route } from 'react-router-dom';
 import Home from './pages/Home/Home';
 import MainPage from './pages/Main/MainPage';
 import PrivateLayout from './routes/PrivateLayout';
+import ResetPasswordPage from './pages/ResetPassword/ResetPasswordPage';
 
 export default function App() {
   return (
     <Routes>
       {/* Rutas públicas */}
       <Route path="/" element={<Home />} />
+      <Route path="/reset-password" element={<ResetPasswordPage />} />
 
       {/* Grupo de rutas privadas */}
       <Route element={<PrivateLayout />}>

--- a/clients/plataforma-principal/src/api/users/passwordResetClient.ts
+++ b/clients/plataforma-principal/src/api/users/passwordResetClient.ts
@@ -1,0 +1,19 @@
+import { authApiUrl } from '../config';
+
+export async function forgotPassword(email: string): Promise<boolean> {
+  const res = await fetch(authApiUrl('/auth/forgot-password'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email }),
+  });
+  return res.status === 204;
+}
+
+export async function resetPassword(token: string, newPassword: string): Promise<boolean> {
+  const res = await fetch(authApiUrl('/auth/reset-password'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ token, newPassword }),
+  });
+  return res.status === 204;
+}

--- a/clients/plataforma-principal/src/pages/Home/components/Login/LoginForm.tsx
+++ b/clients/plataforma-principal/src/pages/Home/components/Login/LoginForm.tsx
@@ -4,6 +4,7 @@ import { FiUser, FiLock, FiEye, FiEyeOff } from 'react-icons/fi';
 import './LoginForm.scss';
 import { useNavigate } from 'react-router-dom';
 import { login, type TokenResponse } from '../../../../api/token/authClient';
+import { forgotPassword } from '../../../../api/users/passwordResetClient'; 
 
 type LoginRequest = { usernameOrEmail: string; password: string };
 
@@ -21,6 +22,11 @@ export default function LoginForm({ onSuccess, onGoRegister }: Props) {
   const [loading, setLoading] = useState(false);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
+  // 👉 estado para el modal "email enviado"
+  const [forgotOpen, setForgotOpen] = useState(false);
+  const [forgotLoading, setForgotLoading] = useState(false);
+  const [maskedEmail, setMaskedEmail] = useState('');
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
     setForm((f) => ({ ...f, [name]: value }));
@@ -34,6 +40,44 @@ export default function LoginForm({ onSuccess, onGoRegister }: Props) {
   }, [form.usernameOrEmail, t]);
 
   const canSubmit = useMemo(() => !clientError && !loading, [clientError, loading]);
+
+  const isValidEmail = (v: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v);
+
+  const maskEmail = (email: string) => {
+    const [u, d] = email.split('@');
+    if (!d) return email;
+    const mUser =
+      u.length <= 2 ? '*'.repeat(u.length) : `${u.at(0)}${'*'.repeat(Math.max(u.length - 2, 1))}${u.at(-1)}`;
+    const dParts = d.split('.');
+    const dn = dParts[0] || '';
+    const rest = dParts.slice(1).join('.');
+    const mDom = dn.length <= 2 ? '*'.repeat(dn.length) : `${dn.at(0)}${'*'.repeat(Math.max(dn.length - 2, 1))}${dn.at(-1)}`;
+    return `${mUser}@${mDom}${rest ? '.' + rest : ''}`;
+  };
+
+  const handleForgot = async (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    if (loading || forgotLoading) return;
+
+    const email = form.usernameOrEmail.trim();
+    if (!isValidEmail(email)) {
+      setErrorMsg(t('emailRequiredForReset') || 'Please enter a valid email to recover your password');
+      return;
+    }
+
+    setErrorMsg(null);
+    setForgotLoading(true);
+    try {
+      // Llamada al backend; siempre mostrará el mismo resultado (204) aunque el email no exista
+      await forgotPassword(email);
+    } catch {
+      // Por privacidad y DX, mostramos el mismo modal aunque falle: el backend tampoco debe revelar nada.
+    } finally {
+      setMaskedEmail(maskEmail(email));
+      setForgotOpen(true);
+      setForgotLoading(false);
+    }
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -52,9 +96,7 @@ export default function LoginForm({ onSuccess, onGoRegister }: Props) {
         password: form.password,
       };
 
-      // 👉 delega en authClient: guarda tokens y maneja expiraciones
       const data = await login(payload);
-
       onSuccess?.(data);
       setForm({ usernameOrEmail: '', password: '' });
       setErrorMsg(null);
@@ -62,7 +104,6 @@ export default function LoginForm({ onSuccess, onGoRegister }: Props) {
     } catch (err: any) {
       const msg = String(err?.message ?? '');
       if (msg.startsWith('LOGIN_FAILED_')) {
-        // 401 u otro status de login
         if (msg.endsWith('_401')) {
           setErrorMsg(t('invalidCredentials') || 'Invalid credentials');
         } else if (msg.endsWith('_400')) {
@@ -81,66 +122,103 @@ export default function LoginForm({ onSuccess, onGoRegister }: Props) {
   };
 
   return (
-    <form className="login-card" onSubmit={handleSubmit} noValidate>
-      <fieldset className="fieldset" disabled={loading}>
-        <div className="pill-input">
-          <span className="left-icon" aria-hidden><FiUser /></span>
-          <input
-            id="usernameOrEmail"
-            name="usernameOrEmail"
-            type="text"
-            autoComplete="username"
-            placeholder={t('usernameOrEmailPlaceholder')}
-            value={form.usernameOrEmail}
-            onChange={handleChange}
-            required
-            aria-invalid={!!(errorMsg && !form.usernameOrEmail.trim())}
-          />
-        </div>
+    <>
+      <form className="login-card" onSubmit={handleSubmit} noValidate>
+        <fieldset className="fieldset" disabled={loading}>
+          <div className="pill-input">
+            <span className="left-icon" aria-hidden><FiUser /></span>
+            <input
+              id="usernameOrEmail"
+              name="usernameOrEmail"
+              type="text"
+              autoComplete="username"
+              placeholder={t('usernameOrEmailPlaceholder')}
+              value={form.usernameOrEmail}
+              onChange={handleChange}
+              required
+              aria-invalid={!!(errorMsg && !form.usernameOrEmail.trim())}
+            />
+          </div>
 
-        <div className="pill-input">
-          <span className="left-icon" aria-hidden><FiLock /></span>
-          <input
-            id="password"
-            name="password"
-            type={showPwd ? 'text' : 'password'}
-            autoComplete="current-password"
-            placeholder={t('passwordPlaceholder')}
-            value={form.password}
-            onChange={handleChange}
-            required
-            minLength={8}
-            aria-invalid={!!(errorMsg && form.password.length < 8)}
-          />
-          <button
-            type="button"
-            className="right-icon"
-            onClick={() => setShowPwd((v) => !v)}
-            aria-label={showPwd ? t('hidePassword') : t('showPassword')}
-          >
-            {showPwd ? <FiEyeOff /> : <FiEye />}
+          <div className="pill-input">
+            <span className="left-icon" aria-hidden><FiLock /></span>
+            <input
+              id="password"
+              name="password"
+              type={showPwd ? 'text' : 'password'}
+              autoComplete="current-password"
+              placeholder={t('passwordPlaceholder')}
+              value={form.password}
+              onChange={handleChange}
+              required
+              minLength={8}
+              aria-invalid={!!(errorMsg && form.password.length < 8)}
+            />
+            <button
+              type="button"
+              className="right-icon"
+              onClick={() => setShowPwd((v) => !v)}
+              aria-label={showPwd ? t('hidePassword') : t('showPassword')}
+            >
+              {showPwd ? <FiEyeOff /> : <FiEye />}
+            </button>
+          </div>
+
+          {/* Enlace "¿Olvidaste la contraseña?" con validación + modal */}
+          <p className="forgot-text">
+            <a
+              href="#forgot"
+              className="forgot-link"
+              onClick={handleForgot}
+              aria-disabled={loading || forgotLoading}
+            >
+              {forgotLoading ? t('sendingReset') : t('forgotPassword')}
+            </a>
+          </p>
+
+          {errorMsg && (
+            <p role="alert" aria-live="polite" className="error">{errorMsg}</p>
+          )}
+
+          <button type="submit" className="primary-button" disabled={!canSubmit}>
+            {loading ? t('loggingIn') : t('login')}
           </button>
-        </div>
 
-        {errorMsg && (
-          <p role="alert" aria-live="polite" className="error">{errorMsg}</p>
-        )}
+          <p className="signup-text">
+            {t('dontHaveAccount')}{' '}
+            <a
+              href="#register"
+              className="signup-link"
+              onClick={(e) => { e.preventDefault(); onGoRegister?.(e); }}
+            >
+              {t('signUp')}
+            </a>
+          </p>
+        </fieldset>
+      </form>
 
-        <button type="submit" className="primary-button" disabled={!canSubmit}>
-          {loading ? t('loggingIn') : t('login')}
-        </button>
-
-        <p className="signup-text">
-          {t('dontHaveAccount')}{' '}
-          <a
-            href="#register"
-            className="signup-link"
-            onClick={(e) => { e.preventDefault(); onGoRegister?.(e); }}
+      {/* Modal de confirmación (reutiliza tus clases de UserMenu) */}
+      {forgotOpen && (
+        <div className="modal-backdrop" onClick={() => setForgotOpen(false)}>
+          <div
+            className="modal"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="reset-title"
+            onClick={(e) => e.stopPropagation()}
           >
-            {t('signUp')}
-          </a>
-        </p>
-      </fieldset>
-    </form>
+            <h3 id="reset-title">{t('resetEmailModal.title')}</h3>
+            <p>
+              {t('resetEmailModal.body', { email: maskedEmail })}
+            </p>
+            <div className="modal-actions">
+              <button type="button" onClick={() => setForgotOpen(false)}>
+                {t('ok')}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
   );
 }

--- a/clients/plataforma-principal/src/pages/ResetPassword/ResetPasswordPage.scss
+++ b/clients/plataforma-principal/src/pages/ResetPassword/ResetPasswordPage.scss
@@ -1,0 +1,123 @@
+.reset-wrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: min(80vh, 900px);
+  padding: 1.25rem;
+}
+
+.reset-card {
+  width: 100%;
+  max-width: 420px;
+  background: #fff;
+  color: #000;
+  border: 1px solid #e7e7e7;
+  border-radius: 16px;
+  padding: 1rem 1rem 1.25rem;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.reset-title {
+  margin: 0;
+  font-size: 1.4rem;
+  font-weight: 500;
+  color: #000;
+}
+
+.reset-desc {
+  margin: 0;
+  color: #444;
+  font-size: 0.95rem;
+}
+
+/* Campos */
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.label {
+  font-size: 0.9rem;
+  color: #000;
+}
+
+.input {
+  appearance: none;
+  width: 100%;
+  padding: 0.75rem 0.9rem;
+  border: 1px solid #e7e7e7;
+  border-radius: 12px;
+  background: #fff;
+  color: #000;
+  outline: none;
+  transition: box-shadow .2s ease, border-color .2s ease;
+
+  &::placeholder { color: #a7a5a5; }
+  &:hover { border-color: #dcdcdc; }
+  &:focus {
+    border-color: #0059ff;
+    box-shadow: 0 0 0 3px rgba(0, 89, 255, 0.15);
+  }
+  &[aria-invalid="true"] {
+    border-color: #e53e3e;
+    box-shadow: 0 0 0 3px rgba(229, 62, 62, 0.12);
+  }
+}
+
+/* Acciones / Botones */
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.button,
+.primary-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 3rem;      /* misma altura */
+  padding: 0 1rem;
+  border-radius: 10px;
+  box-sizing: border-box;
+  line-height: 1;
+  font-size: 0.95rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+/* Secundario (Cancel) */
+.button {
+  border: 1px solid #e7e7e7;
+  background: #fff;
+  color: #000;
+
+  &:disabled { opacity: .6; cursor: not-allowed; }
+}
+
+.button.blue {
+  border: none;
+  background: #0059ff;
+  color: #fff;
+
+  &:hover { background: #004ae0; }
+  &:active { background: #003ec0; }
+  &:focus-visible { box-shadow: 0 0 0 3px rgba(0, 89, 255, 0.2); }
+  &:disabled { opacity: .6; cursor: not-allowed; }
+}
+
+
+
+.error {
+  margin: 0.25rem 0 0;
+  color: #e53e3e;
+  font-size: 0.92rem;
+}
+
+@media (max-width: 480px) {
+  .reset-card { padding: 0.9rem; border-radius: 12px; }
+}

--- a/clients/plataforma-principal/src/pages/ResetPassword/ResetPasswordPage.tsx
+++ b/clients/plataforma-principal/src/pages/ResetPassword/ResetPasswordPage.tsx
@@ -1,0 +1,133 @@
+import { useMemo, useState } from 'react';
+import { useSearchParams, useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { resetPassword } from '../../api/users/passwordResetClient';
+import './ResetPasswordPage.scss';
+
+export default function ResetPasswordPage() {
+  const { t } = useTranslation('ResetPassword');
+  const [params] = useSearchParams();
+  const navigate = useNavigate();
+
+  const token = params.get('token')?.trim() || '';
+  const [pwd, setPwd] = useState('');
+  const [pwd2, setPwd2] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [errorMsg, setError] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+
+  const clientError = useMemo(() => {
+    if (!token) return t('errors.missingToken');
+    if (pwd.length < 8) return t('errors.shortPassword');
+    if (pwd !== pwd2) return t('errors.passwordsDontMatch');
+    return null;
+  }, [token, pwd, pwd2, t]);
+
+  const canSubmit = !!token && !loading && !clientError;
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!canSubmit) return;
+
+    setLoading(true);
+    setError(null);
+    try {
+      const ok = await resetPassword(token, pwd);
+      if (ok) setDone(true);
+      else setError(t('errors.generic'));
+    } catch {
+      setError(t('errors.network'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!token) {
+    return (
+      <div className="reset-wrapper">
+        <div className="reset-card card">
+          <h2 className="reset-title">{t('title')}</h2>
+          <p className="error">{t('errors.missingToken')}</p>
+          <div className="actions">
+            <button onClick={() => navigate('/')} className="primary-button">
+              {t('success.goLogin')}
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (done) {
+    return (
+      <div className="reset-wrapper">
+        <div className="reset-card card">
+          <h2 className="reset-title">{t('success.title')}</h2>
+          <p className="reset-desc">{t('success.body')}</p>
+          <div className="actions">
+            <button onClick={() => navigate('/')} className="primary-button">
+              {t('success.goLogin')}
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="reset-wrapper">
+      <form className="reset-card card" onSubmit={onSubmit} noValidate>
+        <h2 className="reset-title">{t('title')}</h2>
+        <p className="reset-desc">{t('subtitle') || ''}</p>
+
+        <div className="field">
+          <label htmlFor="newPwd" className="label">{t('fields.newPassword')}</label>
+          <input
+            id="newPwd"
+            className="input"
+            type="password"
+            autoComplete="new-password"
+            minLength={8}
+            value={pwd}
+            onChange={(e) => setPwd(e.target.value)}
+            required
+            aria-invalid={!!(clientError && pwd.length < 8)}
+          />
+        </div>
+
+        <div className="field">
+          <label htmlFor="newPwd2" className="label">{t('fields.repeatPassword')}</label>
+          <input
+            id="newPwd2"
+            className="input"
+            type="password"
+            autoComplete="new-password"
+            minLength={8}
+            value={pwd2}
+            onChange={(e) => setPwd2(e.target.value)}
+            required
+            aria-invalid={!!(clientError && pwd !== pwd2)}
+          />
+        </div>
+
+        {errorMsg || clientError ? (
+          <p role="alert" aria-live="polite" className="error">{errorMsg ?? clientError}</p>
+        ) : null}
+
+        <div className="actions">
+          <button
+            type="button"
+            onClick={() => navigate('/')}
+            disabled={loading}
+            className="button"
+          >
+            {t('actions.cancel')}
+          </button>
+          <button type="submit" className="button blue" disabled={!canSubmit}>
+            {loading ? t('states.saving') : t('actions.save')}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/services/ms-auth/pom.xml
+++ b/services/ms-auth/pom.xml
@@ -112,6 +112,20 @@
             <artifactId>swagger-ui</artifactId>
             <version>5.27.1</version>
         </dependency>
+
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>me.paulschwarz</groupId>
+            <artifactId>spring-dotenv</artifactId>
+            <version>4.0.0</version>
+        </dependency>
+
+
     </dependencies>
 
     <build>

--- a/services/ms-auth/src/main/java/com/oscar/proyecto/ms_auth/api/dto/ForgotPasswordRequest.java
+++ b/services/ms-auth/src/main/java/com/oscar/proyecto/ms_auth/api/dto/ForgotPasswordRequest.java
@@ -1,0 +1,8 @@
+package com.oscar.proyecto.ms_auth.api.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record ForgotPasswordRequest(
+        @NotBlank @Email String email
+) {}

--- a/services/ms-auth/src/main/java/com/oscar/proyecto/ms_auth/api/dto/ResetPasswordRequest.java
+++ b/services/ms-auth/src/main/java/com/oscar/proyecto/ms_auth/api/dto/ResetPasswordRequest.java
@@ -1,0 +1,9 @@
+package com.oscar.proyecto.ms_auth.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ResetPasswordRequest(
+        @NotBlank String token,
+        @NotBlank @Size(min = 8, max = 128) String newPassword
+) {}

--- a/services/ms-auth/src/main/java/com/oscar/proyecto/ms_auth/mail/MailSenderPort.java
+++ b/services/ms-auth/src/main/java/com/oscar/proyecto/ms_auth/mail/MailSenderPort.java
@@ -1,0 +1,5 @@
+package com.oscar.proyecto.ms_auth.mail;
+
+public interface MailSenderPort {
+    void send(String to, String subject, String htmlBody);
+}

--- a/services/ms-auth/src/main/java/com/oscar/proyecto/ms_auth/mail/SmtpMailSender.java
+++ b/services/ms-auth/src/main/java/com/oscar/proyecto/ms_auth/mail/SmtpMailSender.java
@@ -1,0 +1,41 @@
+package com.oscar.proyecto.ms_auth.mail;
+
+import jakarta.mail.internet.MimeMessage;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Primary;
+import org.springframework.lang.Nullable;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+@Service
+@Primary
+public class SmtpMailSender implements MailSenderPort {
+
+    private final JavaMailSender mailSender;
+    private final String from;
+    private final String replyTo;
+
+    public SmtpMailSender(JavaMailSender mailSender,
+                          @Value("${app.mail.from:no-reply@localhost}") String from,
+                          @Value("${app.mail.replyTo:}") @Nullable String replyTo) {
+        this.mailSender = mailSender;
+        this.from = from;
+        this.replyTo = replyTo == null ? "" : replyTo;
+    }
+
+    @Override
+    public void send(String to, String subject, String htmlBody) {
+        try {
+            MimeMessage msg = mailSender.createMimeMessage();
+            MimeMessageHelper helper = new MimeMessageHelper(msg, "UTF-8");
+            helper.setFrom(from);
+            helper.setTo(to);
+            if (!replyTo.isBlank()) helper.setReplyTo(replyTo);
+            helper.setSubject(subject);
+            helper.setText(htmlBody, true); // true => HTML
+            mailSender.send(msg);
+        } catch (Exception ignored) {
+        }
+    }
+}

--- a/services/ms-auth/src/main/java/com/oscar/proyecto/ms_auth/password/PasswordResetService.java
+++ b/services/ms-auth/src/main/java/com/oscar/proyecto/ms_auth/password/PasswordResetService.java
@@ -1,0 +1,104 @@
+package com.oscar.proyecto.ms_auth.password;
+
+import com.oscar.proyecto.ms_auth.mail.MailSenderPort;
+import com.oscar.proyecto.ms_auth.token.RefreshTokenService;
+import com.oscar.proyecto.ms_auth.user.User;
+import com.oscar.proyecto.ms_auth.user.UserService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+@Service
+public class PasswordResetService {
+
+    private final UserService userService;
+    private final PasswordResetTokenRepository tokens;
+    private final MailSenderPort mailer;
+    private final RefreshTokenService refreshTokens;
+
+    // TTL del token de reset
+    private final Duration ttl;
+
+    // URL base del frontend para el enlace del email
+    private final String frontendBaseUrl;
+
+    public PasswordResetService(UserService userService,
+                                PasswordResetTokenRepository tokens,
+                                MailSenderPort mailer,
+                                RefreshTokenService refreshTokens,
+                                @Value("${app.password-reset.ttl-minutes:15}") long ttlMinutes,
+                                @Value("${app.frontend-url:http://localhost:5173}") String frontendBaseUrl) {
+        this.userService = userService;
+        this.tokens = tokens;
+        this.mailer = mailer;
+        this.refreshTokens = refreshTokens;
+        this.ttl = Duration.ofMinutes(ttlMinutes);
+        this.frontendBaseUrl = frontendBaseUrl;
+    }
+
+    /**
+     * No revela si el email existe: siempre completa sin error.
+     */
+    @Transactional
+    public void requestReset(String email) {
+        Optional<User> opt = userService.findByEmailIgnoreCase(email);
+        if (opt.isEmpty()) return;
+
+        User user = opt.get();
+
+        // Generar token opaco en claro (para el link) y almacenar SOLO el hash
+        String raw = TokenUtils.newBase64UrlToken();
+        String hash = TokenUtils.sha256Base64Url(raw);
+
+        PasswordResetToken prt = new PasswordResetToken();
+        prt.setUserId(user.getId());
+        prt.setTokenHash(hash);
+        prt.setCreatedAt(Instant.now());
+        prt.setExpiresAt(Instant.now().plus(ttl));
+        tokens.save(prt);
+
+        String url = frontendBaseUrl.replaceAll("/$", "") + "/reset-password?token=" + raw;
+
+        String subject = "Restablece tu contraseña";
+        String body = """
+                <p>Hola %s,</p>
+                <p>Has solicitado restablecer tu contraseña. Este enlace caduca en %d minutos:</p>
+                <p><a href="%s">%s</a></p>
+                <p>Si no fuiste tú, ignora este mensaje.</p>
+                """.formatted(user.getUsername(), ttl.toMinutes(), url, url);
+
+        mailer.send(user.getEmail(), subject, body);
+    }
+
+    /**
+     * Valida token (existencia, no usado, no expirado), cambia contraseña y revoca sesiones.
+     */
+    @Transactional
+    public void reset(String rawToken, String newPassword) {
+        String hash = TokenUtils.sha256Base64Url(rawToken);
+        PasswordResetToken prt = tokens.findByTokenHash(hash)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "TOKEN_INVALID"));
+
+        if (prt.getUsedAt() != null)
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "TOKEN_USED");
+
+        if (Instant.now().isAfter(prt.getExpiresAt()))
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "TOKEN_EXPIRED");
+
+        // Cambiar contraseña del usuario
+        userService.forceChangePassword(prt.getUserId(), newPassword);
+
+        // Marcar token como usado
+        prt.setUsedAt(Instant.now());
+        tokens.save(prt);
+
+        // Revocar todas las sesiones del usuario
+        refreshTokens.revokeAllByUserId(prt.getUserId());
+    }
+}

--- a/services/ms-auth/src/main/java/com/oscar/proyecto/ms_auth/password/PasswordResetToken.java
+++ b/services/ms-auth/src/main/java/com/oscar/proyecto/ms_auth/password/PasswordResetToken.java
@@ -1,0 +1,40 @@
+package com.oscar.proyecto.ms_auth.password;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+
+@Entity
+@Table(name = "password_reset_tokens", indexes = {
+        @Index(name = "idx_prt_token_hash", columnList = "tokenHash", unique = true),
+        @Index(name = "idx_prt_user_id", columnList = "userId")
+})
+public class PasswordResetToken {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false) private Long userId;
+
+    // SHA-256 en base64url (43-44 chars). Guardamos SOLO el hash.
+    @Column(nullable = false, length = 64) private String tokenHash;
+
+    @Column(nullable = false) private Instant expiresAt;
+
+    // null si no se ha usado
+    @Column private Instant usedAt;
+
+    @Column(nullable = false) private Instant createdAt;
+
+    // getters/setters
+    public Long getId() { return id; }
+    public Long getUserId() { return userId; }
+    public void setUserId(Long userId) { this.userId = userId; }
+    public String getTokenHash() { return tokenHash; }
+    public void setTokenHash(String tokenHash) { this.tokenHash = tokenHash; }
+    public Instant getExpiresAt() { return expiresAt; }
+    public void setExpiresAt(Instant expiresAt) { this.expiresAt = expiresAt; }
+    public Instant getUsedAt() { return usedAt; }
+    public void setUsedAt(Instant usedAt) { this.usedAt = usedAt; }
+    public Instant getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+}

--- a/services/ms-auth/src/main/java/com/oscar/proyecto/ms_auth/password/PasswordResetTokenRepository.java
+++ b/services/ms-auth/src/main/java/com/oscar/proyecto/ms_auth/password/PasswordResetTokenRepository.java
@@ -1,0 +1,9 @@
+package com.oscar.proyecto.ms_auth.password;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetToken, Long> {
+    Optional<PasswordResetToken> findByTokenHash(String tokenHash);
+}

--- a/services/ms-auth/src/main/java/com/oscar/proyecto/ms_auth/password/TokenUtils.java
+++ b/services/ms-auth/src/main/java/com/oscar/proyecto/ms_auth/password/TokenUtils.java
@@ -1,0 +1,27 @@
+package com.oscar.proyecto.ms_auth.password;
+
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+final class TokenUtils {
+    private static final SecureRandom RNG = new SecureRandom();
+
+    static String newBase64UrlToken() {
+        byte[] buf = new byte[32];
+        RNG.nextBytes(buf);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(buf);
+    }
+
+    static String sha256Base64Url(String input) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] dig = md.digest(input.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            return Base64.getUrlEncoder().withoutPadding().encodeToString(dig);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private TokenUtils() {}
+}

--- a/services/ms-auth/src/main/java/com/oscar/proyecto/ms_auth/user/UserRepository.java
+++ b/services/ms-auth/src/main/java/com/oscar/proyecto/ms_auth/user/UserRepository.java
@@ -8,4 +8,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByUsername(String username);
     boolean existsByEmail(String email);
     Optional<User> findByEmail(String email);
+    Optional<User> findByEmailIgnoreCase(String email);
 }

--- a/services/ms-auth/src/main/resources/application.yml
+++ b/services/ms-auth/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
   application:
     name: ms-auth
+  main:
+    banner-mode: "off"
   jackson:
     time-zone: Europe/Madrid
     serialization:
@@ -15,6 +17,16 @@ spring:
     hibernate:
       ddl-auto: update
     open-in-view: false
+    show-sql: false
+  mail:
+    host: ${MAIL_HOST:smtp.gmail.com}
+    port: ${MAIL_PORT:587}
+    username: ${MAIL_USERNAME:}
+    password: ${MAIL_PASSWORD:}
+    properties:
+      mail.smtp.auth: true
+      mail.smtp.starttls.enable: true
+      mail.smtp.starttls.required: true
 
 management:
   endpoints:
@@ -23,21 +35,22 @@ management:
         include: health,info,metrics
   endpoint:
     health:
-      show-details: always
+      show-details: when_authorized
 
 logging:
   level:
-    root: INFO
+    root: WARN
     com.oscar.proyecto: INFO
-    org.springframework.web: ERROR
-    org.springframework.security: ERROR
-    org.hibernate.SQL: ERROR
+    org.springframework.web: WARN
+    org.springframework.security: WARN
+    org.hibernate: WARN
+    org.apache.catalina: WARN
 
 server:
   port: 8081
   address: 0.0.0.0
   error:
-    include-message: always
+    include-message: never
     include-binding-errors: never
     include-stacktrace: never
 
@@ -50,16 +63,17 @@ app:
     expiration-minutes: 60
     refresh-expiration-days: ${APP_JWT_REFRESH_EXPIRATION_DAYS:7}
     max-sessions-per-user: 5
+  mail:
+    from: ${MAIL_FROM:${MAIL_USERNAME:oscarpear99@gmail.com}}
+    replyTo: ${MAIL_REPLY_TO:}
 
 security:
-  permit-all: /auth/register,/auth/login,/auth/refresh,/auth/logout,/auth/logout-all,/actuator/health,/actuator/info,/v3/api-docs/**,/swagger-ui.html,/swagger-ui/**
-
+  permit-all: /auth/register,/auth/login,/auth/refresh,/auth/logout,/auth/logout-all,/actuator/health,/actuator/info,/v3/api-docs/**,/swagger-ui.html,/swagger-ui/**,/auth/forgot-password,/auth/reset-password
 
 cors:
   allowed-origins: ""
   allowed-methods: "GET,POST,PUT,DELETE,OPTIONS"
   allowed-headers: "*"
-
 
 springdoc:
   swagger-ui:

--- a/services/ms-auth/src/test/java/com/oscar/proyecto/ms_auth/api/AuthControllerTest.java
+++ b/services/ms-auth/src/test/java/com/oscar/proyecto/ms_auth/api/AuthControllerTest.java
@@ -10,6 +10,7 @@ import com.oscar.proyecto.ms_auth.jwt.JwtService;
 import com.oscar.proyecto.ms_auth.token.RefreshTokenService;
 import com.oscar.proyecto.ms_auth.user.User;
 import com.oscar.proyecto.ms_auth.user.UserService;
+import com.oscar.proyecto.ms_auth.password.PasswordResetService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -41,6 +42,7 @@ class AuthControllerTest {
     @MockitoBean UserService userService;
     @MockitoBean JwtService jwtService;
     @MockitoBean RefreshTokenService refreshTokenService;
+    @MockitoBean PasswordResetService passwordResetService;
 
     @Test
     @DisplayName("POST /auth/login → 200 con token")


### PR DESCRIPTION
feat(auth,ui): reset de contraseña E2E (forgot/reset + modal)

Backend
- Añade POST /auth/forgot-password → siempre 204 (no filtra existencia de email)
- Añade POST /auth/reset-password con token opaco de un solo uso y expiración
- Implementa PasswordResetService (generación, persistencia, invalidación tras uso)
- Envío de email SMTP con token (SmtpMailSender); HTML simple; from/reply-to por config
- Seguridad: agrega endpoints a permit-all y manejo uniforme de errores
- Logging: elimina logs ruidosos, desactiva spring.mail.debug por defecto
- Config: variables app.mail.*, limpieza de application.yml
- Docs: README actualizado con flujo de reset y ejemplos de petición/respuesta
- Swagger/OpenAPI: documentación de los nuevos endpoints

Frontend (cliente)
- Modal `ResetPasswordModal` para cambio de contraseña con validación y estados de carga/error
- Página/flujo “ForgotPassword” (form de email) con feedback 204 genérico
- Routing: soporte a `/reset-password?token=<token>`
- Integración de API: POST /auth/forgot-password y /auth/reset-password (authClient)
- UX: validaciones (min length, coincidencia), mensajes i18n, accesibilidad (labels/aria)
- Tests UI (Jest/RTL): formularios de forgot/reset y apertura del modal
- Config: `API_URL` en entorno y manejo centralizado de errores

Tests
- WebMvcTest: casos de login/refresh/forgot/reset (200/204/401), mocks de servicios
- Unit tests de PasswordResetService: expiración, token inválido, consumo único
